### PR TITLE
Sequentialize to reduce peak memory

### DIFF
--- a/impdar/bin/impdarexec.py
+++ b/impdar/bin/impdarexec.py
@@ -97,8 +97,9 @@ def _get_args():
                                      meters. Second argument is the filename \
                                      (csv or mat) with the new GPS data')
     parser_proc.add_argument('-denoise',
-                             type=str,
-                             help='Denoising filter (scipy wiener for now)')
+                             nargs=2,
+                             type=int,
+                             help='Denoising filter vertical and horizontal (scipy wiener for now)')
     parser_proc.add_argument('-migrate',
                              type=str,
                              help='Migrate with the indicated routine.')

--- a/impdar/lib/convert.py
+++ b/impdar/lib/convert.py
@@ -47,26 +47,24 @@ def convert(fns_in, out_fmt, t_srs=None, in_fmt=None, *args, **kwargs):
         loaders = [lambda x: load(in_fmt, x)[0] for i in fns_in]
 
     # Now actually load the data
-    data = [loader(f) for loader, f in zip(loaders, fns_in)]
+    for loader, fn_i in zip(loaders, fns_in):
+        data = loader(fn_i)
 
-    # Convert
-    if out_fmt == 'mat':
-        for loader, f_i, dat in zip(loaders, fns_in, data):
+        # Convert
+        if out_fmt == 'mat':
             # Guard against silly re-write
             if loader == RadarData and out_fmt == 'mat':
-                continue
-            fn_out = os.path.splitext(f_i)[0] + '.mat'
-            dat.save(fn_out)
-    elif out_fmt == 'shp':
-        for dat in data:
-            fn_out = os.path.splitext(dat.fn)[0] + '.shp'
-            dat.output_shp(fn_out, t_srs=t_srs)
-    elif out_fmt == 'sgy':
-        if not load_segy.SEGY:
-            raise ImportError('You cannot use segy without segyio installed!')
-        for loader, f_i, dat in zip(loaders, fns_in, data):
-            fn_out = os.path.splitext(f_i)[0] + '.sgy'
-            dat.save_as_segy(fn_out)
+                raise ValueError('You are trying a blank conversion that will cause an overwrite...')
+            fn_out = os.path.splitext(data.fn)[0] + '.mat'
+            data.save(fn_out)
+        elif out_fmt == 'shp':
+            fn_out = os.path.splitext(data.fn)[0] + '.shp'
+            data.output_shp(fn_out, t_srs=t_srs)
+        elif out_fmt == 'sgy':
+            if not load_segy.SEGY:
+                raise ImportError('You cannot use segy without segyio installed!')
+            fn_out = os.path.splitext(data.fn)[0] + '.sgy'
+            data.save_as_segy(fn_out)
 
 
 if __name__ == '__main__':

--- a/impdar/lib/load/load_olaf.py
+++ b/impdar/lib/load/load_olaf.py
@@ -15,21 +15,7 @@ import datetime
 import numpy as np
 
 from ..RadarData import RadarData
-
-
-def _common_start(string_a, string_b):
-    """ returns the longest common substring from the beginning of sa and sb.
-
-    from https://stackoverflow.com/questions/18715688/find-common-substring-between-two-strings
-    """
-    def _iter():
-        for char_a, char_b in zip(string_a, string_b):
-            if char_a == char_b:
-                yield char_a
-            else:
-                return
-
-    return ''.join(_iter())
+from .loading_utils import common_start
 
 
 class SInfo:
@@ -350,10 +336,7 @@ def load_olaf(fns_olaf, channel=1):
         fns_olaf = [fns_olaf]
         olaf_data.fn = fns_olaf[0]
     else:
-        f_common = fns_olaf[0]
-        for i in range(1, len(fns_olaf)):
-            f_common = _common_start(f_common, fns_olaf[i]).rstrip('[')
-        olaf_data.fn = f_common
+        olaf_data.fn = common_start(fns_olaf).rstrip('[')
 
     sinfo = []
     stacks = []

--- a/impdar/lib/load/load_osu.py
+++ b/impdar/lib/load/load_osu.py
@@ -15,6 +15,7 @@ import numpy as np
 
 from ..RadarData import RadarData
 from ..RadarFlags import RadarFlags
+from .loading_utils import common_start
 
 def load_osu(fns_osu,*args,**kwargs):
     """ load data from OSU deep radar files, written as .txt """
@@ -22,7 +23,7 @@ def load_osu(fns_osu,*args,**kwargs):
     # We want to be able to use this step concatenate a series of files numbered by the controller
     if isinstance(fns_osu, str):
         fns_osu = [fns_osu]
-    osu_data = fns_osu[0]
+    osu_data.fn = common_start(fns_osu)
 
     dt_s = []
     osu_data.trace_num = []

--- a/impdar/lib/load/loading_utils.py
+++ b/impdar/lib/load/loading_utils.py
@@ -1,0 +1,34 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+#
+# Copyright © 2020 David Lilien <dlilien90@gmail.com>
+#
+# Distributed under terms of the GNU GPL3.0 license.
+
+"""
+Common utilities used by loads of multiple formats.
+"""
+
+
+def common_start(string_list):
+    """Returns the longest common substring from the substings.
+    
+    Made recursive from https://stackoverflow.com/questions/18715688/find-common-substring-between-two-strings
+    """
+    def _cs(string_a, string_b):
+        def _iter():
+            for char_a, char_b in zip(string_a, string_b):
+                if char_a == char_b:
+                    yield char_a
+                else:
+                    return
+        return ''.join(_iter())
+    if len(string_list) == 1:
+        return string_list[0]
+    else:
+        sl = string_list.copy()
+        while len(sl) > 1:
+            sl[-2] = _cs(sl[-2], sl[-1])
+            sl.pop()
+        return sl[0]

--- a/impdar/lib/load/loading_utils.py
+++ b/impdar/lib/load/loading_utils.py
@@ -27,7 +27,8 @@ def common_start(string_list):
     if len(string_list) == 1:
         return string_list[0]
     else:
-        sl = string_list.copy()
+        # copy in a 2/3 safe way
+        sl = string_list[:]
         while len(sl) > 1:
             sl[-2] = _cs(sl[-2], sl[-1])
             sl.pop()

--- a/impdar/tests/test_gecko.py
+++ b/impdar/tests/test_gecko.py
@@ -28,17 +28,5 @@ class TestLoadGecko(unittest.TestCase):
         load_olaf.load_olaf(os.path.join(THIS_DIR, 'input_data', 'test_gecko.gtd'), channel=1)
         load_olaf.load_olaf(os.path.join(THIS_DIR, 'input_data', 'test_gecko.gtd'), channel=2)
 
-    def test_common_start(self):
-        start = load_olaf._common_start('abra', 'abracadabra')
-        self.assertEqual('abra', start)
-
-        start = load_olaf._common_start('abra', 'abra')
-        self.assertEqual('abra', start)
-
-        start = load_olaf._common_start('', 'abra')
-        self.assertEqual('', start)
-
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/impdar/tests/test_loading_utils.py
+++ b/impdar/tests/test_loading_utils.py
@@ -1,0 +1,37 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+#
+# Copyright © 2020 David Lilien <dlilien90@gmail.com>
+#
+# Distributed under terms of the GNU GPL3.0 license.
+
+"""
+Testing loading_utils
+"""
+
+import unittest
+from impdar.lib.load import loading_utils
+
+
+class TestLoadGecko(unittest.TestCase):
+
+    def test_common_start(self):
+        start = loading_utils.common_start(['abra', 'abracadabra'])
+        self.assertEqual('abra', start)
+
+        start = loading_utils.common_start(['abra', 'abra'])
+        self.assertEqual('abra', start)
+
+        start = loading_utils.common_start(['abra', 'abra', 'abracad'])
+        self.assertEqual('abra', start)
+
+        start = loading_utils.common_start(['abra'])
+        self.assertEqual('abra', start)
+
+        start = loading_utils.common_start(['', 'abra'])
+        self.assertEqual('', start)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Operations from the command line are now mostly sequential. This
should reduce peak memory usage for most operations. Exceptions are
concatenating and loading gecko or osu files.

This should take care of most everything in #17, but let's try to get #16 fixed as well before merging.