### PR TITLE
Github Actions is Failing Everywhere

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         qt5: [true, false]
         gdal: [true, false]
         seisunix: [true, false]
@@ -43,7 +43,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools wheel
         # testing
         python -m pip install flake8 pytest
         python -m pip install coverage


### PR DESCRIPTION
This isn't ready to merge yet, but I wanted to bring it up because some changes have come up in the last year. 

Python 6 and ubuntu 22.04 apparently don't play nice together:
https://github.com/actions/setup-python/issues/544
so I removed 3.6 for now. 

Adding a pip upgrade of 'setuptools' was helpful for a few failures as well.

The main remaining issue is gdal, it seems like 3.0.4 disappeared somehow? I may be able to address this one eventually as well.