### PR TITLE
Fixed a bug in "impdar/lib/migrationlib/mig_python.py".

### DIFF
--- a/impdar/lib/migrationlib/mig_python.py
+++ b/impdar/lib/migrationlib/mig_python.py
@@ -145,7 +145,7 @@ def migrationStolt(dat,vel=1.68e8,htaper=100,vtaper=1000):
     h[h>1.] = 1.
     v[v>1.] = 1.
     H,V = np.meshgrid(h,v)
-    dat.data *= H*V
+    dat.data = (H*V)*dat.data
     # 2D Forward Fourier Transform to get data in frequency-wavenumber space, FK = D(kx,z=0,ws)
     FK = np.fft.fft2(dat.data,(dat.snum,dat.tnum))[:dat.snum//2]
     # get the temporal frequencies


### PR DESCRIPTION
In the code, presently, when the "migrate" function is called, it generates an error as shown below:
> …
> numpy.core._exceptions._UFuncOutputCastingError: Cannot cast ufunc 'multiply' output from dtype('float64') to dtype('int16') with casting rule 'same_kind'
> …

The reason for this problem is that the current code will save the result in `dat.data`, however, when the result's data type is `float64`, which cannot be stored in `int32`.

This pull request fixed the bug mentioned in "impdar/lib/migrationlib/mig_python.py."
